### PR TITLE
Close lingering flac processes before mktorrent

### DIFF
--- a/bettered/album.py
+++ b/bettered/album.py
@@ -63,6 +63,7 @@ class Album():
         # transcode all flac files
         LOGGER.info('Transcoding "%s" to "%s"', self.path, bitrate)
         processes = []
+        flac_to_wavs = []
         for root, _, files in os.walk(transcode_dir):
             for file in files:
                 if file.endswith('.flac'):
@@ -88,6 +89,7 @@ class Album():
                     processes.append(subprocess.Popen(
                         shlex.split(transcode_cmd), stdin=flac_to_wav.stdout,
                         stderr=subprocess.PIPE))
+                    flac_to_wavs.append(flac_to_wav)
 
         # wait for transcodes to finish
         for process in processes:
@@ -95,6 +97,8 @@ class Album():
             if process.returncode:
                 # a transcoding processes failed - raise with stderr msg
                 raise ChildProcessError(err)
+        for flac_to_wav in flac_to_wavs:
+            flac_to_wav.communicate()
 
         # remove flac, cue, log, and m3u files from new mp3 directory
         for root, _, files in os.walk(transcode_dir):


### PR DESCRIPTION
After `lame` has finished, the `flac` process that was piped into it lingers idly until bettered exits. In most cases this is fine, but if `transcode_parent_dir` is within an NFS mount, the NFS client sees that the flac file is still open when it's deleted and actually renames it to something like `.nfs000000000000000000000000` behind the scenes. This file makes its way into the torrent and causes it to be rejected by the tracker.

I've added a couple lines to explicitly `communicate()` all of the `flac` instances after all transcoding has finished, allowing the flac files to be closed immediately before being deleted.